### PR TITLE
Expose Error & Fix start_sized

### DIFF
--- a/examples/packet_handler.rs
+++ b/examples/packet_handler.rs
@@ -1,0 +1,35 @@
+extern crate netfilter_queue as nfq;
+
+use std::ptr::null;
+use nfq::handle::{Handle, ProtocolFamily};
+use nfq::queue::{CopyMode, Verdict, PacketHandler, QueueHandle};
+use nfq::message::Message;
+use nfq::error::Error;
+
+fn main() {
+    let mut handle = Handle::new().ok().unwrap();
+    handle.bind(ProtocolFamily::INET).ok().unwrap();
+
+    let mut queue = handle.queue(0, Decider).ok().unwrap();
+    let _ = queue.set_mode(CopyMode::Metadata).unwrap();
+
+    println!("Listening for packets...");
+    handle.start(4096);
+
+    println!("...finished.");
+}
+
+struct Decider;
+
+impl PacketHandler for Decider {
+    #[allow(non_snake_case)]
+    fn handle(&mut self, hq: *mut QueueHandle, message: Result<&Message, &Error>) -> i32 {
+        match message {
+            Ok(m) => {
+                let _ = Verdict::set_verdict(hq, m.header.id(), Verdict::Accept, 0, null());
+            },
+            Err(_) => ()
+        }
+        0
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)]
+
 use libc::c_int;
 use std::error::Error as Base;
 use std::fmt;

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -86,11 +86,12 @@ impl Handle {
     /// Start listening using any attached queues
     ///
     /// This will only listen on queues attached with `queue_builder`.
-    /// `length` determines the amount of a packet to grab from the queue at a time.
+    /// `length` determines the amount of a packet to grab from the queue at a time, in bits.
     /// If you are using `queue::Queue::CopyMode(SIZE)` it must match `SIZE`.
     pub fn start(&mut self, length: u16) {
         unsafe {
-            let buffer: *mut c_void = malloc(mem::size_of::<c_char>() as u64 * length as u64);
+            // TODO: Get rid of malloc
+            let buffer: *mut c_void = malloc(length as u64);
             if buffer.is_null() {
                 panic!("Failed to allocate packet buffer");
             }
@@ -114,7 +115,7 @@ impl Handle {
     /// For example, to parse `IPHeader`, use `start_sized<IPHeader>()`.
     pub fn start_sized<P: Payload>(&mut self) {
         let bytes = mem::size_of::<P>() as u16;
-        // netlink header (128 bites) + payload
+        // netlink header (128 bits) + payload
         self.start(128 + bytes * 8)
     }
 }

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -114,6 +114,7 @@ impl Handle {
     /// For example, to parse `IPHeader`, use `start_sized<IPHeader>()`.
     pub fn start_sized<P: Payload>(&mut self) {
         let bytes = mem::size_of::<P>() as u16;
-        self.start(bytes * 8)
+        // netlink header (128 bites) + payload
+        self.start(128 + bytes * 8)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,10 +11,10 @@ extern crate lazy_static;
 
 mod ffi;
 
-mod error;
 mod util;
 mod lock;
 
+pub mod error;
 pub mod handle;
 pub mod queue;
 pub mod message;


### PR DESCRIPTION
A PacketHandler could not have been implemented before, as Error was never exposed.
start_sized neglected to include the size of the netlink header.
