### PR TITLE
Fixing some breakage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libnfqueue"
 description = "Bindings for the libnetfilter_queue library"
-version = "0.1.0"
+version = "0.2.0"
 authors = [
     "Laurie Clark-Michalek <lclarkmichalek@gmail.com>",
     "Zach Pomerantz <zach@terminal.com>"

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -24,7 +24,6 @@ pub struct nfgenmsg;
 pub struct nfq_data;
 
 #[repr(C)]
-#[packed]
 /// The NFQueue specific packet data
 pub struct nfqnl_msg_packet_hdr {
     /// The packet id


### PR DESCRIPTION
I just made a PR with your upstream:

---

Hey there, I saw this on the latest crater update: https://internals.rust-lang.org/t/new-crater-reports-1-1-stable-vs-beta-2015-07-10-and-nightly-2015-07-10/2358

The `#[packed]` attribute hasn't done anything in a long time, but it was recently removed. So remove it.

Also, bump to 0.2.0, so that users can get the fix. You'll want to publish to crates.io as well.

---

Since you have a package on crates.io as well, you'll want this fix + to update.
